### PR TITLE
Issue#3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.idea/

--- a/formats/8Digits.json
+++ b/formats/8Digits.json
@@ -1,0 +1,16 @@
+{
+  "Description": "8-Digits - NNNNNNNN",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^[0-9]{8}$",
+  "TestData": {
+    "Valid": [
+      "12345678",
+      "56785678"
+    ],
+    "Invalid": [
+      "123345456",
+      "123s33s",
+      "1s23x3"
+    ]
+  }
+}

--- a/formats/BH.json
+++ b/formats/BH.json
@@ -1,0 +1,15 @@
+{
+  "Description": "BH : NNN, NNNN",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^[0-9]{3,4}$",
+  "TestData": {
+    "Valid": [
+      "123",
+      "1234"
+    ],
+    "Invalid": [
+      "12",
+      "12345"
+    ]
+  }
+}

--- a/formats/BN.json
+++ b/formats/BN.json
@@ -1,0 +1,17 @@
+{
+  "Description": "BH : LLNNNN",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^[a-zA-Z]{2}[0-9]{4}$",
+  "TestData": {
+    "Valid": [
+      "AB1234",
+      "tK0987"
+    ],
+    "Invalid": [
+      "abc123",
+      "a12345",
+	  "at123",
+	  "BH12345"
+    ]
+  }
+}

--- a/formats/Fixed.json
+++ b/formats/Fixed.json
@@ -1,0 +1,15 @@
+{
+  "Description": "Countries with fixed postal code should not have anything after their prefix",
+  "RedundantCharacters": "",
+  "ValidationRegex": "^$",
+  "TestData": {
+    "Valid": [
+      ""
+    ],
+    "Invalid": [
+      "1",
+      "a",
+      "123"
+    ]
+  }
+}

--- a/mappings/alpha2-to-formats.json
+++ b/mappings/alpha2-to-formats.json
@@ -1,5 +1,6 @@
 {
   "3Digits.json": [
+	"AD",
     "FO",
     "IS",
     "LS",
@@ -14,7 +15,9 @@
     "AM",
     "AR",
     "AT",
+	"AX",
     "AU",
+	"AZ",
     "BD",
     "BE",
     "BE",
@@ -50,6 +53,7 @@
     "SI",
     "SJ",
     "TN",
+	"VG",
     "ZA"
   ],
   "5Digits.json": [
@@ -138,11 +142,25 @@
     "IL",
     "JP"
   ],
+  "8Digits.json": [
+    "BR"
+  ],
   "BB.json": [
     "BB"
   ],
+  "BH.json": [
+    "BH"
+  ],
+  "BN.json": [
+    "BN"
+  ],
   "CA.json": [
     "CA"
+  ],
+  "Fixed.json": [
+    "AI",
+	"AQ",
+	"IO"
   ],
   "GB.json": [
     "GB"

--- a/mappings/iso-3-country-code-mapping.json
+++ b/mappings/iso-3-country-code-mapping.json
@@ -7,7 +7,8 @@
   "ALA": {
     "iso2CountryCode": "AX",
     "countryName": "Aland Islands",
-    "isoNumericCountryCode": "248"
+    "isoNumericCountryCode": "248",
+	"prefixes": ["", "AX"]
   },
   "ALB": {
     "iso2CountryCode": "AL",
@@ -27,7 +28,8 @@
   "AND": {
     "iso2CountryCode": "AD",
     "countryName": "Andorra",
-    "isoNumericCountryCode": "20"
+    "isoNumericCountryCode": "20",
+	"prefixes": ["AD"]
   },
   "AGO": {
     "iso2CountryCode": "AO",
@@ -37,12 +39,14 @@
   "AIA": {
     "iso2CountryCode": "AI",
     "countryName": "Anguilla",
-    "isoNumericCountryCode": "660"
+    "isoNumericCountryCode": "660",
+	"prefixes": ["AI-2640", "2640"]
   },
   "ATA": {
     "iso2CountryCode": "AQ",
     "countryName": "Antarctica",
-    "isoNumericCountryCode": "10"
+    "isoNumericCountryCode": "10",
+	"prefixes": ["BIQQ 1ZZ", "BIQQ1ZZ"]
   },
   "ATG": {
     "iso2CountryCode": "AG",
@@ -77,7 +81,8 @@
   "AZE": {
     "iso2CountryCode": "AZ",
     "countryName": "Azerbaijan",
-    "isoNumericCountryCode": "31"
+    "isoNumericCountryCode": "31",
+	"prefixes": ["AZ"]
   },
   "BHS": {
     "iso2CountryCode": "BS",
@@ -157,12 +162,14 @@
   "VGB": {
     "iso2CountryCode": "VG",
     "countryName": "British Virgin Islands",
-    "isoNumericCountryCode": "92"
+    "isoNumericCountryCode": "92",
+	"prefixes": ["VG"]
   },
   "IOT": {
     "iso2CountryCode": "IO",
     "countryName": "British Indian Ocean Territory",
-    "isoNumericCountryCode": "86"
+    "isoNumericCountryCode": "86",
+	"prefixes": ["BBND 1ZZ", "BBND1ZZ"]
   },
   "BRN": {
     "iso2CountryCode": "BN",


### PR DESCRIPTION
Introduce prefix for postal codes. Prefix can be used to handle exceptions in validations.

I have done this for the countries that starts with A and B. I wanted to have a common agreement with this approach without going any further.