### PR TITLE
Fix error thrown for countries with no postal codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "0.0.4",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Postal Codes",
   "main": "postal-codes.js",
   "scripts": {

--- a/postal-codes.js
+++ b/postal-codes.js
@@ -5,7 +5,7 @@ const byAlpha3 = require('./generated/postal-codes-alpha3.json');
 const isNode = require('detect-node');
 
 let getFormat = null;
-if ( isNode ) {
+if (isNode) {
     getFormat = require("./formats-node");
 } else {
     getFormat = require("./formats-web");
@@ -13,11 +13,11 @@ if ( isNode ) {
 
 module.exports.validate = function (countryCode, postalCode) {
 
-    if ( !countryCode ) {
+    if (!countryCode) {
         return "Missing country code.";
     }
 
-    if ( !postalCode ) {
+    if (!postalCode) {
         return 'Missing postal code.';
     }
 
@@ -25,21 +25,26 @@ module.exports.validate = function (countryCode, postalCode) {
     let preparedCountryCode = countryCode.trim().toUpperCase();
 
     // Is it alpha2 ?
-    if ( preparedCountryCode.length == 2 ) {
+    if (preparedCountryCode.length == 2) {
         countryData = byAlpha2[preparedCountryCode];
     }
 
     // Is it alpha3 ?
-    if ( preparedCountryCode.length == 3 ) {
+    if (preparedCountryCode.length == 3) {
         countryData = byAlpha3[preparedCountryCode];
     }
 
-    if ( !countryData ) {
+    if (!countryData) {
         return 'Unknown alpha2/alpha3 country code: ' + preparedCountryCode;
     }
 
+    // The country/region does not use postal codes
+    if (!countryData.postalCodeFormat) {
+        return true;
+    }
+
     let format = getFormat(countryData.postalCodeFormat);
-    if ( !format ) {
+    if (!format) {
         return 'Failed to load postal code format "' + countryData.postalCodeFormat + '".';
     }
 
@@ -49,19 +54,19 @@ module.exports.validate = function (countryCode, postalCode) {
     }
 
     let expression = format.ValidationRegex;
-    if ( expression instanceof Array ) {
+    if (expression instanceof Array) {
         expression = '^' + expression.join('|') + '$';
     }
 
     const regexp = new RegExp(expression, 'i');
     let result = regexp.exec(preparedPostalCode);
 
-    if ( !result ) {
+    if (!result) {
         // Invalid postal code
         return "Postal code " + preparedPostalCode + " is not valid for country " + preparedCountryCode;
     }
 
-    if ( result[0].toLowerCase() != preparedPostalCode.toLowerCase() ) {
+    if (result[0].toLowerCase() != preparedPostalCode.toLowerCase()) {
         // Found "sub" match
         return "Postal code " + preparedPostalCode + " is not valid for country " + preparedCountryCode;
     }

--- a/postal-codes.js
+++ b/postal-codes.js
@@ -5,7 +5,7 @@ const byAlpha3 = require('./generated/postal-codes-alpha3.json');
 const isNode = require('detect-node');
 
 let getFormat = null;
-if (isNode) {
+if ( isNode ) {
     getFormat = require("./formats-node");
 } else {
     getFormat = require("./formats-web");
@@ -13,11 +13,11 @@ if (isNode) {
 
 module.exports.validate = function (countryCode, postalCode) {
 
-    if (!countryCode) {
+    if ( !countryCode ) {
         return "Missing country code.";
     }
 
-    if (!postalCode) {
+    if ( !postalCode ) {
         return 'Missing postal code.';
     }
 
@@ -25,26 +25,26 @@ module.exports.validate = function (countryCode, postalCode) {
     let preparedCountryCode = countryCode.trim().toUpperCase();
 
     // Is it alpha2 ?
-    if (preparedCountryCode.length == 2) {
+    if ( preparedCountryCode.length == 2 ) {
         countryData = byAlpha2[preparedCountryCode];
     }
 
     // Is it alpha3 ?
-    if (preparedCountryCode.length == 3) {
+    if ( preparedCountryCode.length == 3 ) {
         countryData = byAlpha3[preparedCountryCode];
     }
 
-    if (!countryData) {
+    if ( !countryData ) {
         return 'Unknown alpha2/alpha3 country code: ' + preparedCountryCode;
     }
 
-    // The country/region does not use postal codes
-    if (!countryData.postalCodeFormat) {
+    // If the country/region does not use postal codes
+    if ( !countryData.postalCodeFormat ) {
         return true;
     }
 
     let format = getFormat(countryData.postalCodeFormat);
-    if (!format) {
+    if ( !format ) {
         return 'Failed to load postal code format "' + countryData.postalCodeFormat + '".';
     }
 
@@ -54,19 +54,19 @@ module.exports.validate = function (countryCode, postalCode) {
     }
 
     let expression = format.ValidationRegex;
-    if (expression instanceof Array) {
+    if ( expression instanceof Array ) {
         expression = '^' + expression.join('|') + '$';
     }
 
     const regexp = new RegExp(expression, 'i');
     let result = regexp.exec(preparedPostalCode);
 
-    if (!result) {
+    if ( !result ) {
         // Invalid postal code
         return "Postal code " + preparedPostalCode + " is not valid for country " + preparedCountryCode;
     }
 
-    if (result[0].toLowerCase() != preparedPostalCode.toLowerCase()) {
+    if ( result[0].toLowerCase() != preparedPostalCode.toLowerCase() ) {
         // Found "sub" match
         return "Postal code " + preparedPostalCode + " is not valid for country " + preparedCountryCode;
     }

--- a/test/validationTests.js
+++ b/test/validationTests.js
@@ -9,7 +9,7 @@ describe('Postal codes validation: ', function () {
     Object.keys(countriesData).map(function (alpha2Code) {
 
         var formatFileName = countriesData[alpha2Code].postalCodeFormat;
-        if (!formatFileName) {
+        if ( !formatFileName ) {
             console.log('Cannot find format file for ' + alpha2Code);
             return;
         }

--- a/test/validationTests.js
+++ b/test/validationTests.js
@@ -90,12 +90,6 @@ describe('Postal codes border cases: ', function () {
             postalCode: 'Hong Kong',
             description: 'should return true all the time because it does not use postal codes',
             expectedResult: true
-        },
-        {
-            countryCode: 'IE',
-            postalCode: 'Anything 321',
-            description: 'should return true all the time because it does not use postal codes',
-            expectedResult: true
         }
     ];
 

--- a/test/validationTests.js
+++ b/test/validationTests.js
@@ -9,7 +9,7 @@ describe('Postal codes validation: ', function () {
     Object.keys(countriesData).map(function (alpha2Code) {
 
         var formatFileName = countriesData[alpha2Code].postalCodeFormat;
-        if ( !formatFileName ) {
+        if (!formatFileName) {
             console.log('Cannot find format file for ' + alpha2Code);
             return;
         }
@@ -83,6 +83,18 @@ describe('Postal codes border cases: ', function () {
             countryCode: ' us ',
             postalCode: ' 98001 ',
             description: 'should trim white spaces in input',
+            expectedResult: true
+        },
+        {
+            countryCode: 'HK',
+            postalCode: 'Hong Kong',
+            description: 'should return true all the time because it does not use postal codes',
+            expectedResult: true
+        },
+        {
+            countryCode: 'IE',
+            postalCode: 'Anything 321',
+            description: 'should return true all the time because it does not use postal codes',
             expectedResult: true
         }
     ];


### PR DESCRIPTION
When a country that doesn't use postal codes (according to the wikipedia link in the readme) is validated there is always a "Path must be a string. Received undefined" error.