### PR TITLE
Fix postal code format of Panama, Monaco & Taiwan

### DIFF
--- a/formats/MC.json
+++ b/formats/MC.json
@@ -1,0 +1,15 @@
+{
+  "Description": "MC : 980NN",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^980[0-9]{2}$",
+  "TestData": {
+    "Valid": [
+      "98000",
+      "98099"
+    ],
+    "Invalid": [
+      "98100",
+      "97099"
+    ]
+  }
+}

--- a/formats/TW.json
+++ b/formats/TW.json
@@ -1,0 +1,17 @@
+{
+  "Description": "TW : NNN[-NN]",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^[0-9]{3}([0-9]{2})?$",
+  "TestData": {
+    "Valid": [
+      "123",
+      "123-45",
+      "12345"
+    ],
+    "Invalid": [
+      "12",
+      "1234",
+      "101010"
+    ]
+  }
+}

--- a/generated/postal-codes-alpha2.json
+++ b/generated/postal-codes-alpha2.json
@@ -980,7 +980,7 @@
     },
     "MC": {
         "countryName": "Monaco",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "MC.json",
         "alpha2": "MC",
         "alpha3": "MCO",
         "numeric3": "492"
@@ -1152,7 +1152,7 @@
     },
     "PA": {
         "countryName": "Panama",
-        "postalCodeFormat": "6Digits.json",
+        "postalCodeFormat": "4Digits.json",
         "alpha2": "PA",
         "alpha3": "PAN",
         "numeric3": "591"
@@ -1464,7 +1464,7 @@
     },
     "TW": {
         "countryName": "Taiwan, Republic of China",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "TW.json",
         "alpha2": "TW",
         "alpha3": "TWN",
         "numeric3": "158"

--- a/generated/postal-codes-alpha3.json
+++ b/generated/postal-codes-alpha3.json
@@ -980,7 +980,7 @@
     },
     "MCO": {
         "countryName": "Monaco",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "MC.json",
         "alpha2": "MC",
         "alpha3": "MCO",
         "numeric3": "492"
@@ -1152,7 +1152,7 @@
     },
     "PAN": {
         "countryName": "Panama",
-        "postalCodeFormat": "6Digits.json",
+        "postalCodeFormat": "4Digits.json",
         "alpha2": "PA",
         "alpha3": "PAN",
         "numeric3": "591"
@@ -1464,7 +1464,7 @@
     },
     "TWN": {
         "countryName": "Taiwan, Republic of China",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "TW.json",
         "alpha2": "TW",
         "alpha3": "TWN",
         "numeric3": "158"

--- a/mappings/alpha2-to-formats.json
+++ b/mappings/alpha2-to-formats.json
@@ -87,7 +87,6 @@
     "LK",
     "LY",
     "MA",
-    "MC",
     "ME",
     "MM",
     "MN",
@@ -109,7 +108,6 @@
     "TD",
     "TH",
     "TR",
-    "TW",
     "TZ",
     "UA",
     "UY",
@@ -218,6 +216,9 @@
   "LV.json": [
     "LV"
   ],
+  "MC.json": [
+    "MC"
+  ],
   "MD.json": [
     "MD"
   ],
@@ -271,6 +272,9 @@
   ],
   "TC.json": [
     "TC"
+  ],
+  "TW.json": [
+    "TW"
   ],
   "US.json": [
     "FM",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Postal Codes",
   "main": "postal-codes.js",
   "scripts": {


### PR DESCRIPTION
#32 Panama post code format NNNN
#32 Monaco post code format 980NN
#31 Taiwan post code format NNN-NN