### PR TITLE
SQUIR-296 Support for Postal code of DK and LU

### DIFF
--- a/formats-web.js
+++ b/formats-web.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const formats = {} ;
+const formats = {};
 
 formats["10Digits.json"] = require("./formats/10Digits.json");
 formats["2Digits.json"] = require("./formats/2Digits.json");
@@ -20,6 +20,7 @@ formats["BH.json"] = require("./formats/BH.json");
 formats["BL.json"] = require("./formats/BL.json");
 formats["BN.json"] = require("./formats/BN.json");
 formats["CA.json"] = require("./formats/CA.json");
+formats["DK.json"] = require("./formats/DK.json");
 formats["FK.json"] = require("./formats/FK.json");
 formats["GB.json"] = require("./formats/GB.json");
 formats["GF.json"] = require("./formats/GF.json");
@@ -33,6 +34,7 @@ formats["KY.json"] = require("./formats/KY.json");
 formats["LB.json"] = require("./formats/LB.json");
 formats["LC.json"] = require("./formats/LC.json");
 formats["LT.json"] = require("./formats/LT.json");
+formats["LU.json"] = require("./formats/LU.json");
 formats["LV.json"] = require("./formats/LV.json");
 formats["MC.json"] = require("./formats/MC.json");
 formats["MD.json"] = require("./formats/MD.json");
@@ -63,6 +65,6 @@ formats["WF.json"] = require("./formats/WF.json");
 formats["WS.json"] = require("./formats/WS.json");
 
 
-module.exports = function getFormat(postalCodeFormat){
+module.exports = function getFormat(postalCodeFormat) {
     return formats[postalCodeFormat];
 };

--- a/formats/DK.json
+++ b/formats/DK.json
@@ -1,0 +1,23 @@
+{
+  "Description": "DK",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^(DK){0,1}\\d{4}$",
+  "TestData": {
+    "Valid": [
+      "1124",
+      "DK1054",
+      "DK-1120",
+      "DK1120",
+      "DK 1125",
+      "DK - 1234",
+      "dk-1123"
+    ],
+    "Invalid": [
+      "1125DK",
+      "DK12345",
+      "DK123",
+      "123",
+      ""
+    ]
+  }
+}

--- a/formats/LU.json
+++ b/formats/LU.json
@@ -1,5 +1,5 @@
 {
-  "Description": "DK",
+  "Description": "LU",
   "RedundantCharacters": " -",
   "ValidationRegex": "^(L){0,1}\\d{4}$",
   "TestData": {

--- a/formats/LU.json
+++ b/formats/LU.json
@@ -1,0 +1,23 @@
+{
+  "Description": "DK",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^(L){0,1}\\d{4}$",
+  "TestData": {
+    "Valid": [
+      "1124",
+      "L1054",
+      "L-1120",
+      "L1120",
+      "L 1125",
+      "L - 1234",
+      "l-1123"
+    ],
+    "Invalid": [
+      "1125L",
+      "L12345",
+      "L123",
+      "123",
+      ""
+    ]
+  }
+}

--- a/generated/postal-codes-alpha2.json
+++ b/generated/postal-codes-alpha2.json
@@ -408,7 +408,7 @@
     },
     "DK": {
         "countryName": "Denmark",
-        "postalCodeFormat": "4Digits.json",
+        "postalCodeFormat": "DK.json",
         "alpha2": "DK",
         "alpha3": "DNK",
         "numeric3": "208"
@@ -871,7 +871,7 @@
     },
     "LU": {
         "countryName": "Luxembourg",
-        "postalCodeFormat": "4Digits.json",
+        "postalCodeFormat": "LU.json",
         "alpha2": "LU",
         "alpha3": "LUX",
         "numeric3": "442"

--- a/mappings/alpha2-to-formats.json
+++ b/mappings/alpha2-to-formats.json
@@ -30,7 +30,6 @@
     "CX",
     "CY",
     "CY",
-    "DK",
     "ET",
     "GE",
     "GL",
@@ -40,7 +39,6 @@
     "HU",
     "LI",
     "LR",
-    "LU",
     "MK",
     "MZ",
     "NE",
@@ -174,6 +172,9 @@
   "CA.json": [
     "CA"
   ],
+  "DK.json": [
+    "DK"
+  ],
   "FK.json": [
     "FK"
   ],
@@ -212,6 +213,9 @@
   ],
   "LT.json": [
     "LT"
+  ],
+  "LU.json": [
+    "LU"
   ],
   "LV.json": [
     "LV"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Postal Codes",
   "main": "postal-codes.js",
   "scripts": {


### PR DESCRIPTION
Adding support for Denmark and Luxembourg postal code in the format:
- DK2000
- DK-2000
- L1222
etc.

Input formats of Denmark Postal Code:
https://en.wikipedia.org/wiki/Postal_codes_in_Denmark

