### PR TITLE
change VNM format rule from 6Digits to 5Digits

### DIFF
--- a/generated/postal-codes-alpha2.json
+++ b/generated/postal-codes-alpha2.json
@@ -1630,7 +1630,7 @@
     },
     "VN": {
         "countryName": "Viet Nam",
-        "postalCodeFormat": "6Digits.json",
+        "postalCodeFormat": "5Digits.json",
         "alpha2": "VN",
         "alpha3": "VNM",
         "numeric3": "704"

--- a/generated/postal-codes-alpha3.json
+++ b/generated/postal-codes-alpha3.json
@@ -1623,7 +1623,7 @@
     },
     "VNM": {
         "countryName": "Viet Nam",
-        "postalCodeFormat": "6Digits.json",
+        "postalCodeFormat": "5Digits.json",
         "alpha2": "VN",
         "alpha3": "VNM",
         "numeric3": "704"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "Postal Codes",
   "main": "postal-codes.js",
   "scripts": {


### PR DESCRIPTION
Postal code rule of VNM has changed.
Now they use 5Digits format for postal code!
Please review it.

Ref. https://en.wikipedia.org/wiki/Postal_codes_in_Vietnam