### PR TITLE
Only publish to npm on NodeV12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ deploy:
   on:
     branch: master
     repo: Cimpress-MCP/postal-codes-js
+    node_js: '12'


### PR DESCRIPTION
Creating a PR to test out the builds (does it run on PRs?) since my fork does not have Travis setup properly (plus the API keys won't work anyways). I have seen this work on documentations so it's worth giving a try.