### PR TITLE
Add declaration file for TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for postal-codes-js
+// Project: https://github.com/Cimpress-MCP/postal-codes-js
+// Definitions by: hborghols <https://github.com/hborghols>
+
+/**
+ * @param countryCode ISO 3166-1 alpha-2 or alpha-3 country code as string.
+ * @param postalCode  Postal code as string or number.
+ * @returns Returns true if valid, error as string otherwise.
+ * */
+
+export function validate(
+  countryCode: string,
+  postalCode: string | number
+): boolean | string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.3.1",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-codes-js",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Postal Codes",
   "main": "postal-codes.js",
   "scripts": {


### PR DESCRIPTION
Adds a declaration file for TypeScript support. For more info on declaration files, see: https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html.

I wanted to use this package in a TypeScript project which involves adding a (simple) declaration file. I thought I would share it with you so you can support typescript users by default 🙂. Thanks for the great work on the package!