### PR TITLE
#62 Make postal code optional for countries without a postal code standard

### DIFF
--- a/postal-codes.js
+++ b/postal-codes.js
@@ -17,10 +17,6 @@ module.exports.validate = function (countryCode, postalCode) {
         return "Missing country code.";
     }
 
-    if ( !postalCode ) {
-        return 'Missing postal code.';
-    }
-
     var countryData = undefined;
     var preparedCountryCode = countryCode.trim().toUpperCase();
 
@@ -41,6 +37,10 @@ module.exports.validate = function (countryCode, postalCode) {
     // If the country/region does not use postal codes
     if ( !countryData.postalCodeFormat ) {
         return true;
+    }
+
+    if ( !postalCode ) {
+      return 'Missing postal code.';
     }
 
     var format = getFormat(countryData.postalCodeFormat);

--- a/test/validationTests.js
+++ b/test/validationTests.js
@@ -50,6 +50,12 @@ describe('Postal codes border cases: ', function () {
             expectedResult: 'Missing postal code.'
         },
         {
+            countryCode: 'bw',
+            postalCode: undefined,
+            description: 'should return true when postal code is undefined and the country does not have a postal code standard',
+            expectedResult: true
+        },
+        {
             countryCode: 'gb',
             postalCode: undefined,
             description: 'should return error when postal code is undefined',


### PR DESCRIPTION
moved the postal code check down and added a test so that empty postal codes are valid as well for countries that don't have a postal code standard