### PR TITLE
Fix typo in regex for GB postcodes

### DIFF
--- a/formats/GB.json
+++ b/formats/GB.json
@@ -1,7 +1,7 @@
 {
   "Description": "GB",
   "RedundantCharacters": " -",
-  "ValidationRegex": "((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([AZa-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))[0-9][A-Za-z]{2})|GIR0AA",
+  "ValidationRegex": "((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z]))))[0-9][A-Za-z]{2})|GIR0AA",
   "ValidationRegex.DOC": "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/488478/Bulk_Data_Transfer_-_additional_validation_valid_from_12_November_2015.pdf",
   "TestData": {
     "Valid": [


### PR DESCRIPTION
Corrected a missing dash in the regular expression used for postcode validation. The old regex failed to properly validate certain postcodes from the list of valid examples, despite the validate function working correctly.

Specifically, the postcodes "W1A 0AX" and "W1U 1BW" (without the redundant spaces) were not validated by the regex due to the missing dash. 

<img width="868" alt="image" src="https://github.com/Cimpress-MCP/postal-codes-js/assets/136079302/b1f004b3-52ca-4260-8ece-6ab1c4c426cb">

It's probably due to an issue with the ValidationRegex.DOC on page 6 here https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/488478/Bulk_Data_Transfer_-_additional_validation_valid_from_12_November_2015.pdf

When you copy the regex it fails to copy the dash as well

<img width="864" alt="image" src="https://github.com/Cimpress-MCP/postal-codes-js/assets/136079302/df8a6d62-34ae-4224-90a1-bb497106ff91">
